### PR TITLE
Adds code coverage tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ SpaceX Ruby Client
 
 [![Gem Version](https://badge.fury.io/rb/spacex.svg)](https://badge.fury.io/rb/spacex)
 [![Build Status](https://travis-ci.com/rodolfobandeira/spacex.svg?branch=master)](https://travis-ci.org/rodolfobandeira/spacex)
+[![Coverage Status](https://coveralls.io/repos/github/harman28/spacex/badge.svg?branch=master)](https://coveralls.io/github/harman28/spacex?branch=master)
 
 Ruby library that consumes SpaceX API
 

--- a/lib/spacex/base_request.rb
+++ b/lib/spacex/base_request.rb
@@ -11,11 +11,6 @@ module SPACEX
       SPACEX::Response.new(data.get.body)
     end
 
-    def self.retrieve_all(path)
-      data = call_api(path)
-      data.get.body.map { |k| [k] }
-    end
-
     def self.call_api(path)
       Faraday.new(
         url: "#{SPACEX::ROOT_URI}/#{path}",

--- a/spacex.gemspec
+++ b/spacex.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'faraday', '>= 0.9'
   s.add_dependency 'faraday_middleware'
   s.add_dependency 'hashie', '3.6.0'
+  s.add_development_dependency 'coveralls'
   s.add_development_dependency 'rake', '~> 10'
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'rubocop', '0.51.0'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,14 @@
 
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..'))
 
+if ENV['CI']
+  require 'coveralls'
+  Coveralls.wear!
+else
+  require 'simplecov'
+  SimpleCov.start
+end
+
 require 'rubygems'
 require 'rspec'
 require 'spacex'


### PR DESCRIPTION
Adds `coveralls` to gemspec, which includes `simplecov` as a dependency. This allows local test runs to generate a coverage file using simplecov, while coveralls takes care of Travis-hosted runs.

Removed an unused function from `base_request` to achieve 100% code coverage. Please let me know if this is to be reverted for some reason.

Finally, added a coverage badge. At the moment this points to my own fork on coveralls, but will change this to the primary repo when coveralls is added by @rodolfobandeira [here](https://coveralls.io/repos/new?name=rodolfobandeira&service=github).