### PR TITLE
Fixes dependencies

### DIFF
--- a/lib/spacex/base_request.rb
+++ b/lib/spacex/base_request.rb
@@ -1,5 +1,3 @@
-require 'byebug'
-
 module SPACEX
   class Response < Hashie::Mash
     disable_warnings

--- a/spacex.gemspec
+++ b/spacex.gemspec
@@ -17,12 +17,12 @@ Gem::Specification.new do |s|
   s.files       = `git ls-files`.split("\n")
   s.test_files  = `git ls-files -- spec/*`.split("\n")
   s.require_paths = ['lib']
-  s.add_dependency 'faraday', '>= 0.9'
-  s.add_dependency 'faraday_middleware'
+  s.add_dependency 'faraday', '~> 0.9'
+  s.add_dependency 'faraday_middleware', '~> 0.12'
   s.add_dependency 'hashie', '3.6.0'
   s.add_development_dependency 'rake', '~> 10'
-  s.add_development_dependency 'rspec'
+  s.add_development_dependency 'rspec', '~> 3.8'
   s.add_development_dependency 'rubocop', '0.51.0'
-  s.add_development_dependency 'vcr'
-  s.add_development_dependency 'webmock'
+  s.add_development_dependency 'vcr', '~> 4'
+  s.add_development_dependency 'webmock', '~> 3.4'
 end

--- a/spec/spacex/dragon_capsules_spec.rb
+++ b/spec/spacex/dragon_capsules_spec.rb
@@ -1,5 +1,4 @@
 require 'spec_helper'
-require 'byebug'
 
 describe SPACEX do
   context 'DragonCapsules', vcr: { cassette_name: 'dragon_capsules/info' } do


### PR DESCRIPTION
* Removes open-ended dependencies from gemspec
Without this, the following warning were prompted on building the gem:
```
WARNING:  open-ended dependency on faraday (>= 0.9) is not recommended
  if faraday is semantically versioned, use:
    add_runtime_dependency 'faraday', '~> 0.9'
WARNING:  open-ended dependency on faraday_middleware (>= 0) is not recommended
  if faraday_middleware is semantically versioned, use:
    add_runtime_dependency 'faraday_middleware', '~> 0'
WARNING:  open-ended dependency on rspec (>= 0, development) is not recommended
  if rspec is semantically versioned, use:
    add_development_dependency 'rspec', '~> 0'
WARNING:  open-ended dependency on vcr (>= 0, development) is not recommended
  if vcr is semantically versioned, use:
    add_development_dependency 'vcr', '~> 0'
WARNING:  open-ended dependency on webmock (>= 0, development) is not recommended
  if webmock is semantically versioned, use:
    add_development_dependency 'webmock', '~> 0'
WARNING:  See http://guides.rubygems.org/specification-reference/ for help
```

* Removes unlisted gem 'byebug' from load path
Without this, usage of the gem immediately after installation (without installing byebug) results in:
```
> pry
[1] pry(main)> require 'spacex'
LoadError: cannot load such file -- byebug
```