### PR TITLE
Only expose info method in endpoints

### DIFF
--- a/lib/spacex/dragon_capsules.rb
+++ b/lib/spacex/dragon_capsules.rb
@@ -27,6 +27,12 @@ module SPACEX
     property 'description'
 
     class << self
+      def info(dragon_id = nil)
+        get(dragon_id)
+      end
+
+      private
+
       def retrieve_all
         data = SPACEX::BaseRequest.call_api('dragons')
         data.get.body.map { |k| SPACEX::DragonCapsules.new(k) }
@@ -37,10 +43,6 @@ module SPACEX
 
         data = SPACEX::BaseRequest.get("dragons/#{dragon_id}")
         SPACEX::DragonCapsules.new(data)
-      end
-
-      def info(dragon_id = nil)
-        get(dragon_id)
       end
     end
   end

--- a/lib/spacex/missions.rb
+++ b/lib/spacex/missions.rb
@@ -12,6 +12,12 @@ module SPACEX
     property 'description'
 
     class << self
+      def info(mission_id = nil)
+        get(mission_id)
+      end
+
+      private
+
       def retrieve_all
         data = SPACEX::BaseRequest.call_api('missions')
         data.get.body.map { |k| SPACEX::Missions.new(k) }
@@ -22,10 +28,6 @@ module SPACEX
 
         data = SPACEX::BaseRequest.get("missions/#{mission_id}")
         SPACEX::Missions.new(data)
-      end
-
-      def info(mission_id = nil)
-        get(mission_id)
       end
     end
   end

--- a/lib/spacex/ships.rb
+++ b/lib/spacex/ships.rb
@@ -27,6 +27,12 @@ module SPACEX
     property 'image'
 
     class << self
+      def info(ship_id = nil)
+        get(ship_id)
+      end
+
+      private
+
       def retrieve_all
         data = SPACEX::BaseRequest.call_api('ships')
         data.get.body.map { |k| SPACEX::Ships.new(k) }
@@ -37,10 +43,6 @@ module SPACEX
 
         data = SPACEX::BaseRequest.get("ships/#{ship_id}")
         SPACEX::Ships.new(data)
-      end
-
-      def info(ship_id = nil)
-        get(ship_id)
       end
     end
   end


### PR DESCRIPTION
The `retrieve_all` and `get` methods are not to be called by the consumers so they can be `private`