### PR TITLE
Retrieve all abstraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ### 0.0.8 (next)
 
-* [#42](https://github.com/rodolfobandeira/spacex/pull/42): Abstracts `retrieve_all` method in capsules, cores, dragon_capsules, missions, rockets, and ships resources. Adds in ResourceService module to house the abstracted `retrieve_all` method and potential future abstractions.
+* [#43](https://github.com/rodolfobandeira/spacex/pull/43): Abstracts `retrieve_all` method in capsules, cores, dragon_capsules, missions, rockets, and ships resources. Adds in ResourceService module to house the abstracted `retrieve_all` method and potential future abstractions.
 * [#40](https://github.com/rodolfobandeira/spacex/pull/40): Update and clarify information in README -
   [@annawinkler](https://github.com/annawinkler).
 * [#34](https://github.com/rodolfobandeira/spacex/pull/34): Implement Capsules endpoint - [@efl7a](https://github.com/efl7a).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ### 0.0.8 (next)
 
-* Your contribution here.
+* [#42](https://github.com/rodolfobandeira/spacex/pull/42): Abstracts `retrieve_all` method in capsules, cores, dragon_capsules, missions, rockets, and ships resources. Adds in ResourceService module to house the abstracted `retrieve_all` method and potential future abstractions.
 * [#40](https://github.com/rodolfobandeira/spacex/pull/40): Update and clarify information in README -
   [@annawinkler](https://github.com/annawinkler).
 * [#34](https://github.com/rodolfobandeira/spacex/pull/34): Implement Capsules endpoint - [@efl7a](https://github.com/efl7a).

--- a/lib/resource_service.rb
+++ b/lib/resource_service.rb
@@ -1,0 +1,12 @@
+module ResourceService
+
+  def hello
+    puts 'hello'
+  end
+
+  def retrieve_all(resource)
+    data = SPACEX::BaseRequest.call_api(resource)
+    thing = data.get.body.map { |k| new(k) }
+  end
+end
+

--- a/lib/resource_service.rb
+++ b/lib/resource_service.rb
@@ -1,12 +1,6 @@
 module ResourceService
-
-  def hello
-    puts 'hello'
-  end
-
   def retrieve_all(resource)
     data = SPACEX::BaseRequest.call_api(resource)
-    thing = data.get.body.map { |k| new(k) }
+    data.get.body.map { |k| new(k) }
   end
 end
-

--- a/lib/spacex/capsules.rb
+++ b/lib/spacex/capsules.rb
@@ -1,3 +1,5 @@
+require_relative '../resource_service'
+
 module SPACEX
   class Capsules < Hashie::Trash
     include Hashie::Extensions::IgnoreUndeclared
@@ -13,19 +15,16 @@ module SPACEX
     property 'details'
 
     class << self
+      include ResourceService
+
       def info(capsule_serial = nil)
         get(capsule_serial)
       end
 
       private
 
-      def retrieve_all
-        data = SPACEX::BaseRequest.call_api('capsules')
-        data.get.body.map { |k| SPACEX::Capsules.new(k) }
-      end
-
       def get(capsule_serial = nil)
-        return retrieve_all if capsule_serial.nil?
+        return retrieve_all('capsules') if capsule_serial.nil?
 
         data = SPACEX::BaseRequest.get("capsules/#{capsule_serial}")
         SPACEX::Capsules.new(data)

--- a/lib/spacex/cores.rb
+++ b/lib/spacex/cores.rb
@@ -1,3 +1,5 @@
+require_relative '../resource_service'
+
 module SPACEX
   class Cores < Hashie::Trash
     include Hashie::Extensions::IgnoreUndeclared
@@ -16,19 +18,16 @@ module SPACEX
     property 'details'
 
     class << self
+      include ResourceService
+
       def info(core_serial = nil)
         get(core_serial)
       end
 
       private
 
-      def retrieve_all
-        data = SPACEX::BaseRequest.call_api('cores')
-        data.get.body.map { |k| SPACEX::Cores.new(k) }
-      end
-
       def get(core_serial = nil)
-        return retrieve_all if core_serial.nil?
+        return retrieve_all('cores') if core_serial.nil?
 
         data = SPACEX::BaseRequest.get("cores/#{core_serial}")
         SPACEX::Cores.new(data)

--- a/lib/spacex/dragon_capsules.rb
+++ b/lib/spacex/dragon_capsules.rb
@@ -1,3 +1,5 @@
+require_relative '../resource_service'
+
 module SPACEX
   class DragonCapsules < Hashie::Trash
     include Hashie::Extensions::IgnoreUndeclared
@@ -27,19 +29,16 @@ module SPACEX
     property 'description'
 
     class << self
+      include ResourceService
+
       def info(dragon_id = nil)
         get(dragon_id)
       end
 
       private
 
-      def retrieve_all
-        data = SPACEX::BaseRequest.call_api('dragons')
-        data.get.body.map { |k| SPACEX::DragonCapsules.new(k) }
-      end
-
       def get(dragon_id = nil)
-        return retrieve_all if dragon_id.nil?
+        return retrieve_all('dragons') if dragon_id.nil?
 
         data = SPACEX::BaseRequest.get("dragons/#{dragon_id}")
         SPACEX::DragonCapsules.new(data)

--- a/lib/spacex/missions.rb
+++ b/lib/spacex/missions.rb
@@ -15,17 +15,12 @@ module SPACEX
 
     class << self
       include ResourceService
-      
+
       def info(mission_id = nil)
         get(mission_id)
       end
 
       private
-
-      # def retrieve_all
-      #   data = SPACEX::BaseRequest.call_api('missions')
-      #   data.get.body.map { |k| SPACEX::Missions.new(k) }
-      # end
 
       def get(mission_id = nil)
         return retrieve_all('missions') if mission_id.nil?

--- a/lib/spacex/missions.rb
+++ b/lib/spacex/missions.rb
@@ -1,3 +1,5 @@
+require_relative '../resource_service'
+
 module SPACEX
   class Missions < Hashie::Trash
     include Hashie::Extensions::IgnoreUndeclared
@@ -12,19 +14,21 @@ module SPACEX
     property 'description'
 
     class << self
+      include ResourceService
+      
       def info(mission_id = nil)
         get(mission_id)
       end
 
       private
 
-      def retrieve_all
-        data = SPACEX::BaseRequest.call_api('missions')
-        data.get.body.map { |k| SPACEX::Missions.new(k) }
-      end
+      # def retrieve_all
+      #   data = SPACEX::BaseRequest.call_api('missions')
+      #   data.get.body.map { |k| SPACEX::Missions.new(k) }
+      # end
 
       def get(mission_id = nil)
-        return retrieve_all if mission_id.nil?
+        return retrieve_all('missions') if mission_id.nil?
 
         data = SPACEX::BaseRequest.get("missions/#{mission_id}")
         SPACEX::Missions.new(data)

--- a/lib/spacex/rockets.rb
+++ b/lib/spacex/rockets.rb
@@ -1,3 +1,5 @@
+require_relative '../resource_service'
+
 module SPACEX
   class Rockets < Hashie::Trash
     include Hashie::Extensions::IgnoreUndeclared
@@ -26,19 +28,16 @@ module SPACEX
     property 'rocket_type'
 
     class << self
+      include ResourceService
+
       def info(rocket_id = nil)
         get(rocket_id)
       end
 
       private
 
-      def retrieve_all
-        data = SPACEX::BaseRequest.call_api('rockets')
-        data.get.body.map { |k| SPACEX::Rockets.new(k) }
-      end
-
       def get(rocket_id = nil)
-        return retrieve_all if rocket_id.nil?
+        return retrieve_all('rockets') if rocket_id.nil?
 
         data = SPACEX::BaseRequest.get("rockets/#{rocket_id}")
         SPACEX::Rockets.new(data)

--- a/lib/spacex/ships.rb
+++ b/lib/spacex/ships.rb
@@ -1,3 +1,5 @@
+require_relative '../resource_service'
+
 module SPACEX
   class Ships < Hashie::Trash
     include Hashie::Extensions::IgnoreUndeclared
@@ -27,19 +29,16 @@ module SPACEX
     property 'image'
 
     class << self
+      include ResourceService
+
       def info(ship_id = nil)
         get(ship_id)
       end
 
       private
 
-      def retrieve_all
-        data = SPACEX::BaseRequest.call_api('ships')
-        data.get.body.map { |k| SPACEX::Ships.new(k) }
-      end
-
       def get(ship_id = nil)
-        return retrieve_all if ship_id.nil?
+        return retrieve_all('ships') if ship_id.nil?
 
         data = SPACEX::BaseRequest.get("ships/#{ship_id}")
         SPACEX::Ships.new(data)


### PR DESCRIPTION
Hi! 👋 

As a potential refactor, I choose to abstract the `retrieve_all` method in the following resources and creates a ResourceService module to include in these resources to mix in the abstracted method.

* capsules.rb
* cores.rb
* dragon_capsules.rb
* missions.rb
* rockets.rb
* ships.rb

The new method just adds the need for one argument, which is a string that is the name of the requested resource. This update is made in the private `get` method in each resource.

- [X] All tests are passing.
- [X] Rubocop linting passes.
- [X] CHANGELOG has been updated.

Please let me know if there are any additional changes that I can make to this PR and I will be happy to do so!