### PR TITLE
Fix: CVE-2020-8130

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 1.0.3 (next)
 
 * Your contribution here.
+* [#74](https://github.com/rodolfobandeira/spacex/pull/74): Fix vulnerable dependency: Rake. Bump to version 12 [@rodolfobandeira](https://github.com/rodolfobandeira).
 
 ### 1.0.2 (2019/10/06)
 

--- a/spacex.gemspec
+++ b/spacex.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'faraday_middleware', '~> 0.12'
   s.add_dependency 'hashie', '3.6.0'
   s.add_development_dependency 'coveralls'
-  s.add_development_dependency 'rake', '~> 10'
+  s.add_development_dependency 'rake', '>= 12.3.3'
   s.add_development_dependency 'rspec', '~> 3.8'
   s.add_development_dependency 'rubocop', '0.51.0'
   s.add_development_dependency 'vcr', '~> 4'


### PR DESCRIPTION
#### Why?
**CVE-2020-8130**
Security fix on dependency used on spacex dev mode

#### Description
Vulnerability on dependency `rake` on versions <= 10

Details: https://github.com/advisories/GHSA-jppv-gw3r-w3q8


