### PR TITLE
Preparation for SpaceX API v4 support

### DIFF
--- a/lib/spacex/base_request.rb
+++ b/lib/spacex/base_request.rb
@@ -5,17 +5,15 @@ module SPACEX
 
   module BaseRequest
     class << self
-      def info(path, klass = nil, params = {})
-        response_body = get(path, params).body
+      def info(path, klass = nil, version = 'v3')
+        response_body = get(path, version).body
         process(response_body, klass)
       end
 
       private
 
-      def get(path, params)
-        conn(path).get do |req|
-          req.params = params
-        end
+      def get(path, version)
+        conn(path, version).get
       end
 
       def process(response_body, klass)
@@ -40,9 +38,9 @@ module SPACEX
         SPACEX::Response.new(response)
       end
 
-      def conn(path)
+      def conn(path, version)
         Faraday.new(
-          url: "#{SPACEX::ENDPOINT_URI}/#{path}",
+          url: "#{SPACEX::BASE_URI}/#{version}/#{path}",
           request: {
             params_encoder: Faraday::FlatParamsEncoder
           }

--- a/lib/spacex/endpoint.rb
+++ b/lib/spacex/endpoint.rb
@@ -1,3 +1,3 @@
 module SPACEX
-  ENDPOINT_URI = 'https://api.spacexdata.com/v3'.freeze
+  BASE_URI = 'https://api.spacexdata.com'.freeze
 end

--- a/spec/spacex/endpoint_spec.rb
+++ b/spec/spacex/endpoint_spec.rb
@@ -1,9 +1,9 @@
 require 'spec_helper'
 
-describe SPACEX::ENDPOINT_URI do
-  subject { SPACEX::ENDPOINT_URI }
+describe SPACEX::BASE_URI do
+  subject { SPACEX::BASE_URI }
 
-  it 'returns the URI for v3 of the SpaceX API' do
-    expect(subject).to eq 'https://api.spacexdata.com/v3'
+  it 'returns the BASE URI for the SpaceX API' do
+    expect(subject).to eq 'https://api.spacexdata.com'
   end
 end


### PR DESCRIPTION
#### Why?
- SpaceX API now has a [V4](https://github.com/r-spacex/SpaceX-API/blob/master/docs/v4/README.md) available.
- In order to make this gem support the v4 endpoints, we should be able to pass v4 path as a parameter
- That way, we can continue to support v3 as well as v4 API endpoints

#### Description
- Updated BaseRequest to accept a version parameter which we will then append to the base endpoint path
- Updated related specs
