### PR TITLE
Add a configurable simplecov to set a coverage threshold.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,9 @@
 source 'http://rubygems.org'
 
+group :development, :test do
+  gem 'simplecov', require: false
+end
+
 group :development do
   gem 'rubocop', '~> 1.22', require: false
 end

--- a/spec/coverage_helper.rb
+++ b/spec/coverage_helper.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+require 'simplecov'
+SimpleCov.minimum_coverage 93
+SimpleCov.start 'rails'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,9 +6,8 @@ if ENV['CI']
   require 'coveralls'
   Coveralls.wear!
 else
+  require 'coverage_helper'
   require 'pry'
-  require 'simplecov'
-  SimpleCov.start
 end
 
 require 'rubygems'


### PR DESCRIPTION
#### Why?
This will add a configurable place to set the minimum spec coverage percentage and the files that needs the coverage for conitinous quality development.

#### Description
The current spec coverage is 93.84% which is good. Every time we run the spec we will now see the current coverage and the build will only pass if the coverage is met.

<img width="1617" alt="image" src="https://user-images.githubusercontent.com/4223130/136050639-c4b39966-798c-4449-b1ca-48e80fa91830.png">

<img width="884" alt="image" src="https://user-images.githubusercontent.com/4223130/136050682-d412877e-11e7-4fdc-bc4b-82a2250f2bda.png">


