### PR TITLE
Fix Rubocop warnings

### DIFF
--- a/lib/spacex/v4/capsules.rb
+++ b/lib/spacex/v4/capsules.rb
@@ -13,7 +13,7 @@ module SPACEX
       property 'type'
       property 'water_landings'
 
-      def self.info(capsule_serial = nil, query = {})
+      def self.info(capsule_serial = nil, _query = {})
         SPACEX::BaseRequest.info("capsules/#{capsule_serial}", SPACEX::V4::Capsules, 'v4')
       end
     end

--- a/spec/spacex/v4/capsules_spec.rb
+++ b/spec/spacex/v4/capsules_spec.rb
@@ -26,7 +26,7 @@ describe SPACEX::V4::Capsules do
   end
 
   context "#info('5e9e2c5bf35918ed873b2664')",
-    vcr: { cassette_name: 'v4/capsules/5e9e2c5bf35918ed873b2664' } do
+          vcr: { cassette_name: 'v4/capsules/5e9e2c5bf35918ed873b2664' } do
     subject do
       SPACEX::V4::Capsules.info('5e9e2c5bf35918ed873b2664')
     end


### PR DESCRIPTION
#### Why?
Rubocop warnings added after V4::Capsules PR was merged

#### Description
Just did a `rubocop -a`
