### PR TITLE
[Misc] Fix the variable name used for V4::Capsules

### DIFF
--- a/docs/v4.md
+++ b/docs/v4.md
@@ -8,6 +8,8 @@
 - Get information for all capsules: `SPACEX::V4::Capsules.info`
 - Get information about a specific capsule: `SPACEX::V4::Capsules.info('id')`
 
+**NOTE:** As of v4, the capsule.info uses the capsule's `id` and not `serial` as it did in v3.
+
 This example shows how to get capsules information and what the data fields are for that object:
 
 ```ruby

--- a/lib/spacex/v4/capsules.rb
+++ b/lib/spacex/v4/capsules.rb
@@ -13,8 +13,8 @@ module SPACEX
       property 'type'
       property 'water_landings'
 
-      def self.info(capsule_serial = nil, _query = {})
-        SPACEX::BaseRequest.info("capsules/#{capsule_serial}", SPACEX::V4::Capsules, 'v4')
+      def self.info(id = nil, _query = {})
+        SPACEX::BaseRequest.info("capsules/#{id}", SPACEX::V4::Capsules, 'v4')
       end
     end
   end


### PR DESCRIPTION
#### Why?
- As of V4, the capsules endpoint to retrieve information about a specific capsule uses the id and not serial as it used to in v4
- The code was still calling the variable `capsule_serial` which is not accurate
- While this does not affect the functionality of the API, it is better to use the right variable name to avoid confusion in the future

#### Description
- Changed the argument name
- Updated v4.md readme
